### PR TITLE
hiera examples for multiple listeners and vault enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ vault::config_hash:
     listener:
         tcp:
             address: "%{::fqdn}:8200"
-            tls_disable: 1
+            tls_disable: true
     telemetry:
         statsite_address: '127.0.0.1:8125'
         disable_hostname: true
@@ -43,6 +43,28 @@ vault::package_ensure: 'latest'
 vault::vault_user: 'vault'
 vault::restart_cmd: '/etc/init.d/vault restart'
 ````
+
+To run multiple listeners, for example disabling TLS on 127.0.0.1, but requiring TLS from external hosts
+````
+    listener:
+        - tcp:
+            address: "127.0.0.1:8200"
+            tls_disable: true
+        - tcp:
+            address: "%{::fqdn}:8200"
+            tls_cert_file: "/path/to/cert.pub"
+            tls_key_file:  "/path/to/private.key"
+````
+
+[Vault Enterprise customers using a PKCS#11 HSM](https://atlas.hashicorp.com/help/vault/hsm/configuration) might do...
+```
+    hsm:
+        pkcs11:
+            lib: "/path/to/libpkcs11.so"
+            slot: "0"
+            key_label: "vault"
+            pin: "Goofus commits secrets to repos. Gallant uses $VAULT_HSM_PIN"
+```
 
 # Uninstalling Vault
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ To run multiple listeners, for example disabling TLS on 127.0.0.1, but requiring
             key_label: "vault"
             pin: "Goofus commits secrets to repos. Gallant uses $VAULT_HSM_PIN"
 ```
+The puppet-vault module uses a SysV init script. Those wishing to avoid putting the PIN in Hiera in plaintext could, for example, create an `/etc/default/vault`, owned by root and only readable by root, looking like...
+```
+export VAULT_HSM_PIN="correct horse battery staple"
+```
 
 # Uninstalling Vault
 


### PR DESCRIPTION
Hi @rhoml,

While straightforward in HCL, the syntax to get multiple listeners working is not well-documented in JSON. I'd like to add an example of it to the README.

HashiCorp also sells [Vault Enterprise](https://www.hashicorp.com/vault.html), which adds PKCS#11 support. Configuration is documented at https://atlas.hashicorp.com/help/vault/hsm/configuration

<!--- 50-character subject line is recommended --->
<!--- 72-character wrapped longer description answering the questions above --->

